### PR TITLE
docs(repo-info.yaml): add repository mapping

### DIFF
--- a/.github/repo-info.yaml
+++ b/.github/repo-info.yaml
@@ -1,0 +1,35 @@
+# The following GitHub teams can be used as owners within this file:
+# affinity
+# analytics
+# architects
+# audiences
+# datafeeds
+# core
+# cse
+# cto
+# data-science
+# devops
+# devsecops
+# dy4dev
+# dy4dev-client
+# fi
+# frontend
+# frontend-latvia
+# frontend-infra
+# messaging
+# messaging-engine
+# noc
+# qa
+# qsr
+# recs
+# ses
+# strategy
+Owner: dy4dev
+# The following environments can be used within this file:
+# production
+# non-production
+#
+# production repository - application/package (or part of) that is deployed in AWS.
+# non-production repository - docs, template, tests, local environment, ci/cd code, etc.
+Environment: production
+# In case you're not sure or need further assistance please reach out to DevOps


### PR DESCRIPTION
Adding `repo-info.yaml` file for internal mapping of our GitHub repositories as part of [DY-49024](https://dynamicyield.atlassian.net/browse/DY-49024) Jira ticket.
Please verify the information in this file is correct and update accordingly if needed.
In case your repository is a template repository, please close this PR and adjust the [repo-exclude.txt](https://github.com/DynamicYield/repository-mapping/blob/master/repo-exclude.txt) file accordingly.

**Please do not delete this file.**

The following GitHub teams can be used as `Owner` within this file:
- affinity
- analytics
- architects
- audiences
- datafeeds
- core
- cse
- cto
- data-science
- devops
- devsecops
- dy4dev
- dy4dev-client
- fi
- frontend
- frontend-latvia
- frontend-infra
- messaging
- messaging-engine
- noc
- qa
- qsr
- recs
- ses
- strategy

The following environments can be used as `Environment` within this file:
- production
- non-production

`production` repository - application/package (or part of) that is deployed in AWS.
`non-production` repository - docs, tests, local environment, ci/cd code, etc.

In case you're not sure or need further assistance please reach out to DevOps.

[DY-49024]: https://dynamicyield.atlassian.net/browse/DY-49024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ